### PR TITLE
Centralize env configuration

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,17 @@
+# SIMPREDE environment configuration template
+# Copy this file to .env and fill in the values
+
+# Database configuration
+DB_USER=
+DB_PASSWORD=
+DB_HOST=
+DB_PORT=6543
+DB_NAME=postgres
+DB_SCHEMA=google_scraper
+DB_SSLMODE=require
+
+# Google Cloud Storage configuration
+GCS_PROJECT_ID=
+GCS_BUCKET_NAME=
+GCS_LOCATION=EUROPE-WEST1
+GOOGLE_APPLICATION_CREDENTIALS=./config/gcs-credentials.json

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .venv
 venv
 .env
+!.env.template
 .venv*/
 
 #backups

--- a/Simprede_scrapers/README.md
+++ b/Simprede_scrapers/README.md
@@ -66,6 +66,7 @@ cd simprede-airflow
 Execute o script de arranque que configura automaticamente o ambiente:
 
 ```bash
+cp .env.template .env
 chmod +x start_airflow.sh
 ./start_airflow.sh
 ```
@@ -204,6 +205,7 @@ simprede-airflow/
 ├── Dockerfile                     # Configuração Docker Airflow
 ├── docker-compose.yml            # Orquestração de serviços
 ├── requirements.txt               # Dependências Python
+├── .env.template                # Exemplo de configuração
 ├── .env                          # Variáveis de ambiente
 ├── README.md                     # Este ficheiro
 ├── start_airflow.sh              # Script de arranque

--- a/Simprede_scrapers/scripts/google_scraper/exportador_bd/export_to_supabase_airflow.py
+++ b/Simprede_scrapers/scripts/google_scraper/exportador_bd/export_to_supabase_airflow.py
@@ -95,26 +95,10 @@ def get_database_config():
     if not db_config['host'] or not db_config['user'] or not db_config['password']:
         log_progress("🔍 Configuração da base de dados não encontrada no ambiente, procurando ficheiro .env...")
         
-        # Look for .env file in multiple locations
+        # Look for .env file only at project root
         possible_env_paths = [
-            '/opt/airflow/.env',  # Airflow container root
-            '/opt/airflow/scripts/google_scraper/.env',
-            '/opt/airflow/scripts/.env',
-            os.path.join(os.path.dirname(__file__), '../../../../.env'),
-            os.path.join(os.path.dirname(__file__), '../../../.env'),
-            os.path.join(os.path.dirname(__file__), '../../.env'),
-            os.path.join(os.path.dirname(__file__), '../.env'),
-            os.path.join(os.path.dirname(__file__), '.env')
+            Path(__file__).resolve().parents[4] / '.env'
         ]
-        
-        # Add absolute path resolution
-        script_dir = os.path.dirname(os.path.abspath(__file__))
-        additional_paths = [
-            os.path.join(script_dir, '../../../../.env'),
-            os.path.join(script_dir, '../../../.env'),
-            '/Users/ruicarvalho/Desktop/projects/SIMPREDE/simprede-airflow/.env'  # Absolute fallback
-        ]
-        possible_env_paths.extend(additional_paths)
         
         # Remove duplicates while preserving order
         seen = set()

--- a/Simprede_scrapers/scripts/google_scraper/tests/test_connection.py
+++ b/Simprede_scrapers/scripts/google_scraper/tests/test_connection.py
@@ -5,9 +5,10 @@ import os
 import psycopg2
 import time
 from dotenv import load_dotenv
+from pathlib import Path
 
-# 🔐 Carregar variáveis do .env
-load_dotenv()
+# 🔐 Carregar variáveis do .env localizado na raiz do projeto
+load_dotenv(Path(__file__).resolve().parents[4] / '.env')
 
 DB_USER = os.getenv("DB_USER")
 DB_PASSWORD = os.getenv("DB_PASSWORD")

--- a/Simprede_scrapers/scripts/google_scraper/utils/export_centroids_to_supabase.py
+++ b/Simprede_scrapers/scripts/google_scraper/utils/export_centroids_to_supabase.py
@@ -8,10 +8,11 @@ from sqlalchemy import create_engine
 import logging
 from typing import List, Dict, Any, Literal
 from dotenv import load_dotenv
+from pathlib import Path
 import geopandas as gpd
 
-# Load environment variables from .env file
-load_dotenv()
+# Load environment variables from the project root .env file
+load_dotenv(Path(__file__).resolve().parents[4] / '.env')
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')


### PR DESCRIPTION
## Summary
- provide a `.env.template` at the repo root
- allow tracking of the template in `.gitignore`
- load root `.env` in export scripts and tests
- document copying `.env.template` in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: psycopg2, requests, selenium)*

------
https://chatgpt.com/codex/tasks/task_e_685019ac0a548331961688b258f42109